### PR TITLE
Implement task posting and dashboards

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import ForgotPasswordPage from './pages/ForgotPasswordPage';
 import ResetPasswordPage from './pages/ResetPasswordPage';
 import ProfilePage from './pages/ProfilePage';
 import MessagesPage from './pages/MessagesPage'; // ✅ Add this
+import PostTaskPage from './pages/PostTaskPage';
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
         <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/messages" element={<MessagesPage />} /> {/* ✅ New route */}
+        <Route path="/tasks/new" element={<PostTaskPage />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -17,7 +17,7 @@ const LandingPage = () => {
         <div className="hero-text">
           <h1>Snagged</h1>
           <p>
-            Land more interviews with less effort — Snagged connects you with affordable help to apply for internships while you focus on what matters most.
+            Apply like a boss without lifting a finger. Snagged pairs you with fellow students ready to grind through applications so you can vibe and study.
           </p>
           <a href="/signup" className="cta-button">Get Started</a>
         </div>
@@ -28,8 +28,8 @@ const LandingPage = () => {
 
       <section className="features">
         <div className="feature-box">
-          <h3>🌍 <strong>Global Helpers</strong></h3>
-          <p>Find trusted overseas assistants to do your internship applications for you — faster and cheaper than you'd expect.</p>
+          <h3>🌍 <strong>Global Snaggers</strong></h3>
+          <p>Find trusted Snaggers worldwide to knock out your internship apps — way faster and cheaper than doing it solo.</p>
         </div>
         <div className="feature-box">
           <h3>💸 <strong>Price Flexibility</strong></h3>
@@ -37,7 +37,7 @@ const LandingPage = () => {
         </div>
         <div className="feature-box">
           <h3>🤝 <strong>Like a Social Network</strong></h3>
-          <p>Think Fiverr meets LinkedIn — but built for job application help. Review profiles, chat with helpers, and get your apps submitted stress-free.</p>
+          <p>Think Fiverr meets LinkedIn — but built for job applications. Scope profiles, chat with Snaggers, and get your apps sent stress-free.</p>
         </div>
       </section>
 

--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -23,56 +23,98 @@ const MainPage = () => {
           <button onClick={() => navigate('/profile')} className="nav-button">Profile</button>
         </div>
       </nav>
-      {role === 'student' ? <StudentDashboard /> : role === 'assistant' ? <AssistantDashboard /> : <div>Unauthorized</div>}
+      {role === 'student' ? <StudentDashboard /> : role === 'snagger' ? <SnaggerDashboard /> : <div>Unauthorized</div>}
     </div>
   );
 };
 
-const StudentDashboard = () => (
-  <div className="dashboard-container">
-    <aside className="sidebar">
-      <h2>Find Application Assistants for Your Job Search</h2>
-      <p>Browse profiles of experienced assistants who can help with your job applications.</p>
-      <button className="primary-btn">Post a Request</button>
-    </aside>
-    <main className="dashboard-main">
-      <h1>Featured Application Assistants</h1>
-      <div className="assistant-grid">
-        {[1, 2, 3, 4].map((id) => (
-          <div key={id} className="assistant-profile">
-            <img src={`https://via.placeholder.com/100?text=A${id}`} alt={`Assistant ${id}`} />
-            <h3>Assistant #{id}</h3>
-            <p>Application Specialist</p>
-            <p className="rating">⭐ 4.{id} stars</p>
-            <p>20+ applications completed</p>
-            <button>Message</button>
-          </div>
-        ))}
-      </div>
-    </main>
-  </div>
-);
+const StudentDashboard = () => {
+  const navigate = useNavigate();
+  return (
+    <div className="dashboard-container">
+      <aside className="sidebar">
+        <h2>Find Snaggers to Handle Your Applications</h2>
+        <p>Browse profiles of experienced snaggers who can help with your job applications.</p>
+        <button className="primary-btn" onClick={() => navigate('/tasks/new')}>Post a Request</button>
+      </aside>
+      <main className="dashboard-main">
+        <h1>Featured Snaggers</h1>
+        <div className="assistant-grid">
+          {[1, 2, 3, 4].map((id) => (
+            <div key={id} className="assistant-profile">
+              <img src={`https://via.placeholder.com/100?text=S${id}`} alt={`Snagger ${id}`} />
+              <h3>Snagger #{id}</h3>
+              <p>Application Specialist</p>
+              <p className="rating">⭐ 4.{id} stars</p>
+              <p>20+ applications completed</p>
+              <button>Message</button>
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+};
 
-const AssistantDashboard = () => (
-  <div className="dashboard-container">
-    <aside className="sidebar">
-      <h2>Find Students Looking for Help</h2>
-      <p>Offer assistance and help students apply to jobs and internships.</p>
-      <button className="primary-btn">Browse Requests</button>
-    </aside>
-    <main className="dashboard-main">
-      <h1>Available Student Requests</h1>
-      <div className="assistant-grid">
-        {[1, 2].map((id) => (
-          <div key={id} className="assistant-profile">
-            <h3>Student #{id}</h3>
-            <p>Needs help with 10 internship applications.</p>
-            <button>Offer Help</button>
-          </div>
-        ))}
-      </div>
-    </main>
-  </div>
-);
+const SnaggerDashboard = () => {
+  const [tasks, setTasks] = useState([]);
+  const [filters, setFilters] = useState({ minBudget: '', location: '', major: '' });
+  const token = localStorage.getItem('token');
+
+  const fetchTasks = async () => {
+    const params = new URLSearchParams();
+    if (filters.minBudget) params.append('minBudget', filters.minBudget);
+    if (filters.location) params.append('location', filters.location);
+    if (filters.major) params.append('major', filters.major);
+    try {
+      const res = await fetch(`https://snagged.onrender.com/api/tasks?${params.toString()}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      setTasks(data);
+    } catch (err) {
+      console.error('fetch tasks error', err);
+    }
+  };
+
+  useEffect(() => { fetchTasks(); }, []);
+
+  const handleChange = (e) => setFilters({ ...filters, [e.target.name]: e.target.value });
+  const handleFilter = (e) => { e.preventDefault(); fetchTasks(); };
+
+  const claimTask = async (id) => {
+    await fetch(`https://snagged.onrender.com/api/tasks/${id}/claim`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    fetchTasks();
+  };
+
+  return (
+    <div className="dashboard-container">
+      <aside className="sidebar">
+        <h2>Filter Tasks</h2>
+        <form onSubmit={handleFilter} className="signup-form">
+          <input name="minBudget" type="number" placeholder="Min Budget" value={filters.minBudget} onChange={handleChange} />
+          <input name="location" type="text" placeholder="Location" value={filters.location} onChange={handleChange} />
+          <input name="major" type="text" placeholder="Major" value={filters.major} onChange={handleChange} />
+          <button className="primary-btn" type="submit">Apply</button>
+        </form>
+      </aside>
+      <main className="dashboard-main">
+        <h1>Open Tasks</h1>
+        <div className="assistant-grid">
+          {tasks.map((task) => (
+            <div key={task._id} className="assistant-profile">
+              <h3>{task.student?.name}</h3>
+              <p>{task.numberOfApplications} apps — ${task.budget}</p>
+              <button onClick={() => claimTask(task._id)}>Claim</button>
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+};
 
 export default MainPage;

--- a/client/src/pages/MessagesPage.jsx
+++ b/client/src/pages/MessagesPage.jsx
@@ -1,38 +1,75 @@
 // src/pages/MessagesPage.jsx
-import React, { useState } from 'react';
-
-const sampleConversations = [
-  {
-    id: 1,
-    name: 'Alex Johnson',
-    message: 'Yo, did you see my last post?',
-    time: '2m ago',
-  },
-  {
-    id: 2,
-    name: 'Jamie Rivera',
-    message: 'We should collab on that project fr',
-    time: '1h ago',
-  },
-];
+import React, { useState, useEffect } from 'react';
 
 const MessagesPage = () => {
-  const [messages, setMessages] = useState(sampleConversations);
+  const [messages, setMessages] = useState([]);
+  const [to, setTo] = useState('');
+  const [content, setContent] = useState('');
+  const token = localStorage.getItem('token');
+
+  const fetchMessages = async () => {
+    if (!to) return;
+    try {
+      const res = await fetch(`https://snagged.onrender.com/api/messages/${to}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      setMessages(data);
+    } catch (err) {
+      console.error('fetch messages error', err);
+    }
+  };
+
+  useEffect(() => { fetchMessages(); }, [to]);
+
+  const handleSend = async (e) => {
+    e.preventDefault();
+    try {
+      await fetch('https://snagged.onrender.com/api/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ to, content }),
+      });
+      setContent('');
+      fetchMessages();
+    } catch (err) {
+      console.error('send message error', err);
+    }
+  };
 
   return (
     <div className="signup-container">
       <h2 style={{ textAlign: 'center' }}>Messages</h2>
+      <input
+        type="text"
+        placeholder="Recipient user ID"
+        value={to}
+        onChange={(e) => setTo(e.target.value)}
+        style={{ marginBottom: '1rem' }}
+      />
       <div className="message-list">
         {messages.map((msg) => (
-          <div key={msg.id} className="message-card">
+          <div key={msg._id} className="message-card">
             <div>
-              <strong>{msg.name}</strong>
-              <p style={{ margin: '0.25rem 0' }}>{msg.message}</p>
+              <strong>{msg.from === to ? 'Them' : 'You'}</strong>
+              <p style={{ margin: '0.25rem 0' }}>{msg.content}</p>
             </div>
-            <span className="message-time">{msg.time}</span>
           </div>
         ))}
       </div>
+      <form onSubmit={handleSend} style={{ marginTop: '1rem' }}>
+        <input
+          type="text"
+          placeholder="Type a message..."
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          required
+        />
+        <button className="primary-btn" type="submit">Send</button>
+      </form>
     </div>
   );
 };

--- a/client/src/pages/PostTaskPage.jsx
+++ b/client/src/pages/PostTaskPage.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import '../App.css';
+
+const PostTaskPage = () => {
+  const [formData, setFormData] = useState({
+    numberOfApplications: '',
+    resumeLink: '',
+    jobTypePreference: '',
+    locationPreference: '',
+    deadline: '',
+    budget: '',
+  });
+  const navigate = useNavigate();
+  const role = localStorage.getItem('role');
+  if (role !== 'student') {
+    return <div className="signup-container">Unauthorized</div>;
+  }
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    try {
+      const res = await fetch('https://snagged.onrender.com/api/tasks', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(formData),
+      });
+      if (res.ok) {
+        navigate('/main');
+      } else {
+        alert('Failed to post task');
+      }
+    } catch (err) {
+      console.error('post task error', err);
+      alert('Server error');
+    }
+  };
+
+  return (
+    <div className="signup-container">
+      <h2 className="signup-title">Post a Task</h2>
+      <form className="signup-form" onSubmit={handleSubmit}>
+        <input
+          type="number"
+          name="numberOfApplications"
+          placeholder="Number of applications"
+          value={formData.numberOfApplications}
+          onChange={handleChange}
+          required
+        />
+        <input
+          type="text"
+          name="resumeLink"
+          placeholder="Resume Google Drive link"
+          value={formData.resumeLink}
+          onChange={handleChange}
+          required
+        />
+        <input
+          type="text"
+          name="jobTypePreference"
+          placeholder="Preferred job type"
+          value={formData.jobTypePreference}
+          onChange={handleChange}
+        />
+        <input
+          type="text"
+          name="locationPreference"
+          placeholder="Preferred location"
+          value={formData.locationPreference}
+          onChange={handleChange}
+        />
+        <input
+          type="date"
+          name="deadline"
+          value={formData.deadline}
+          onChange={handleChange}
+        />
+        <input
+          type="number"
+          name="budget"
+          placeholder="Budget in USD"
+          value={formData.budget}
+          onChange={handleChange}
+          required
+        />
+        <button className="submit-button" type="submit">Create Task</button>
+      </form>
+    </div>
+  );
+};
+
+export default PostTaskPage;

--- a/client/src/pages/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage.jsx
@@ -9,6 +9,9 @@ const ProfilePage = () => {
   const [username, setUsername] = useState(storedUser?.name || '');
   const [email, setEmail] = useState(storedUser?.email || '');
   const [profilePic, setProfilePic] = useState(defaultAvatar);
+  const [bio, setBio] = useState(storedUser?.bio || '');
+  const [major, setMajor] = useState(storedUser?.major || '');
+  const [location, setLocation] = useState(storedUser?.location || '');
   const [message, setMessage] = useState('');
 
   const handleImageChange = (e) => {
@@ -23,7 +26,7 @@ const ProfilePage = () => {
   const handleSave = (e) => {
     e.preventDefault();
     // This would usually send a request to backend to update profile
-    localStorage.setItem('user', JSON.stringify({ name: username, email }));
+    localStorage.setItem('user', JSON.stringify({ name: username, email, bio, major, location }));
     setMessage('Profile updated successfully');
   };
 
@@ -64,12 +67,31 @@ const ProfilePage = () => {
           onChange={(e) => setEmail(e.target.value)}
           required
         />
+        <input
+          type="text"
+          placeholder="Major"
+          value={major}
+          onChange={(e) => setMajor(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+        />
+        <textarea
+          placeholder="Bio"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+          rows="3"
+        />
 
         <button type="submit" className="submit-button">Save Changes</button>
         <button type="button" className="primary-btn" onClick={handleResetPassword}>Reset Password</button>
         <button type="button" className="primary-btn" onClick={handleLogout}>Logout</button>
 
         {message && <p style={{ color: 'green', textAlign: 'center' }}>{message}</p>}
+        <p style={{ textAlign: 'center', marginTop: '1rem' }}>⭐ 4.5/5 from 10 reviews</p>
       </form>
     </div>
   );

--- a/client/src/pages/SignupPage.jsx
+++ b/client/src/pages/SignupPage.jsx
@@ -74,7 +74,7 @@ const SignupPage = () => {
         />
         <select name="role" onChange={handleChange} required>
           <option value="student">Student</option>
-          <option value="assistant">Assistant</option>
+          <option value="snagger">Snagger</option>
         </select>
         <button className="submit-button" type="submit">
           Create Account

--- a/server/index.js
+++ b/server/index.js
@@ -41,6 +41,9 @@ app.use('/api/protected', protectedRoutes);
 const messageRoutes = require('./routes/messages');
 app.use('/api/messages', messageRoutes);
 
+const taskRoutes = require('./routes/tasks');
+app.use('/api/tasks', taskRoutes);
+
 // Default route
 app.get('/', (req, res) => {
   res.send('Snagged API is running');

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -18,6 +18,10 @@ const messageSchema = new mongoose.Schema({
   timestamp: {
     type: Date,
     default: Date.now
+  },
+  read: {
+    type: Boolean,
+    default: false,
   }
 });
 

--- a/server/models/Task.js
+++ b/server/models/Task.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const taskSchema = new mongoose.Schema({
+  student: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  snagger: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  numberOfApplications: { type: Number, required: true },
+  resumeLink: { type: String, required: true },
+  jobTypePreference: String,
+  locationPreference: String,
+  deadline: Date,
+  budget: { type: Number, required: true },
+  status: { type: String, enum: ['open', 'claimed', 'completed'], default: 'open' },
+  proofLink: String,
+}, { timestamps: true });
+
+module.exports = mongoose.model('Task', taskSchema);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -5,7 +5,11 @@ const userSchema = new mongoose.Schema({
   email: { type: String, required: true, unique: true },
   password: { type: String }, // Optional for Google users
   googleId: { type: String }, // For Google OAuth
-  role: { type: String, enum: ['student', 'assistant'], required: true },
+  role: { type: String, enum: ['student', 'snagger'], required: true },
+  bio: { type: String },
+  major: { type: String },
+  location: { type: String },
+  reviews: [{ type: Number }],
 
   // Password reset fields
   resetToken: { type: String },

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const router = express.Router();
+const Task = require('../models/Task');
+const verifyToken = require('../middleware/verifyToken');
+
+// create task
+router.post('/', verifyToken, async (req, res) => {
+  if (req.user.role !== 'student') {
+    return res.status(403).json({ message: 'Only students can create tasks' });
+  }
+  try {
+    const task = await Task.create({ ...req.body, student: req.user.id });
+    res.status(201).json(task);
+  } catch (err) {
+    console.error('Task creation error:', err);
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+});
+
+// get tasks with optional filters
+router.get('/', verifyToken, async (req, res) => {
+  const { minBudget, maxBudget, location, major } = req.query;
+  const filter = { status: 'open' };
+  if (minBudget) filter.budget = { ...filter.budget, $gte: Number(minBudget) };
+  if (maxBudget) filter.budget = { ...filter.budget, $lte: Number(maxBudget) };
+  if (location) filter.locationPreference = location;
+  if (major) filter.jobTypePreference = major;
+  try {
+    const tasks = await Task.find(filter).populate('student', 'name');
+    res.json(tasks);
+  } catch (err) {
+    console.error('Task fetch error:', err);
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+});
+
+// claim task
+router.put('/:id/claim', verifyToken, async (req, res) => {
+  if (req.user.role !== 'snagger') {
+    return res.status(403).json({ message: 'Only snaggers can claim tasks' });
+  }
+  try {
+    const task = await Task.findById(req.params.id);
+    if (!task) return res.status(404).json({ message: 'Task not found' });
+    if (task.status !== 'open') return res.status(400).json({ message: 'Task already claimed' });
+    task.snagger = req.user.id;
+    task.status = 'claimed';
+    await task.save();
+    res.json(task);
+  } catch (err) {
+    console.error('Task claim error:', err);
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Task model and task routes
- extend User and Message models
- integrate task routes into server
- enhance landing page copy
- update dashboards and create task posting form
- basic DM-style chat page
- update profile page fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6878773f2f648333aeb9a36bab37ff84