### PR TITLE
Improve styling and API config

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Snagged</title>
 
     <!-- Global font -->
     <link

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,12 +1,13 @@
 :root {
-  --primary-color: #6366f1;
-  --primary-hover: #4f46e5;
-  --bg-color: #f9fafb;
-  --card-bg: #ffffff;
-  --text-color: #1f2937;
-  --border-color: #e5e7eb;
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.1);
-  --shadow-md: 0 2px 6px rgba(0,0,0,0.15);
+  /* Dark mode palette */
+  --primary-color: #4b5563;
+  --primary-hover: #6b7280;
+  --bg-color: #111827;
+  --card-bg: #1f2937;
+  --text-color: #f3f4f6;
+  --border-color: #374151;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.4);
+  --shadow-md: 0 2px 6px rgba(0,0,0,0.5);
 }
 
 html {
@@ -116,7 +117,7 @@ a {
 .hero-text p {
   font-size: 1.125rem;
   margin-bottom: 2rem;
-  color: #4b5563;
+  color: #d1d5db;
 }
 
 .hero-image img {
@@ -181,7 +182,8 @@ a {
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
   font-size: 1rem;
-  background-color: #fff;
+  background-color: var(--bg-color);
+  color: var(--text-color);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -190,13 +192,13 @@ a {
 .signup-form textarea:focus,
 .text-input:focus {
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+  box-shadow: 0 0 0 3px rgba(107, 114, 128, 0.2);
   outline: none;
 }
 
 .google-login-button {
   margin-top: 0.5rem;
-  background-color: #fff;
+  background-color: var(--bg-color);
   color: var(--primary-color);
   border: 1px solid var(--primary-color);
   display: flex;
@@ -205,7 +207,7 @@ a {
 }
 
 .google-login-button:hover {
-  background-color: rgba(99, 102, 241, 0.1);
+  background-color: var(--primary-hover);
 }
 
 .google-logo {

--- a/client/src/pages/ForgotPasswordPage.jsx
+++ b/client/src/pages/ForgotPasswordPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const ForgotPasswordPage = () => {
   const [email, setEmail] = useState('');
@@ -10,7 +11,7 @@ const ForgotPasswordPage = () => {
     e.preventDefault();
 
     try {
-      const res = await axios.post('https://snagged.onrender.com/api/auth/forgot-password', {
+      const res = await axios.post(`${API_BASE}/auth/forgot-password`, {
         email,
       });
       setMessage(res.data.message || 'Reset email sent if user exists.');

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import { useNavigate, Link } from 'react-router-dom';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const LoginPage = () => {
   const [email, setEmail] = useState('');
@@ -18,7 +19,7 @@ const LoginPage = () => {
     setErrorMsg('');
 
     try {
-      const res = await axios.post('https://snagged.onrender.com/api/auth/login', {
+      const res = await axios.post(`${API_BASE}/auth/login`, {
         email,
         password,
       });
@@ -73,7 +74,7 @@ const LoginPage = () => {
           type="button"
           className="google-login-button"
           onClick={() =>
-            (window.location.href = 'https://snagged.onrender.com/api/auth/google')
+            (window.location.href = `${API_BASE}/auth/google`)
           }
         >
           <img

--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const MainPage = () => {
   const [role, setRole] = useState(null);
@@ -70,7 +71,7 @@ const SnaggerDashboard = () => {
     if (filters.campus) params.append('campus', filters.campus);
 
     try {
-      const res = await fetch(`https://snagged.onrender.com/api/tasks?${params.toString()}`, {
+      const res = await fetch(`${API_BASE}/tasks?${params.toString()}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -86,7 +87,7 @@ const SnaggerDashboard = () => {
   const handleFilter = (e) => { e.preventDefault(); fetchTasks(); };
 
   const claimTask = async (id) => {
-    await fetch(`https://snagged.onrender.com/api/tasks/${id}/claim`, {
+    await fetch(`${API_BASE}/tasks/${id}/claim`, {
       method: 'PUT',
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/client/src/pages/MessagesPage.jsx
+++ b/client/src/pages/MessagesPage.jsx
@@ -1,5 +1,6 @@
 // Basic messaging UI - merge conflicts resolved
 import React, { useState, useEffect, useCallback } from 'react';
+import { API_BASE } from '../utils/api';
 
 const MessagesPage = () => {
   const [messages, setMessages] = useState([]);
@@ -10,7 +11,7 @@ const MessagesPage = () => {
   const fetchMessages = useCallback(async () => {
     if (!to) return;
     try {
-      const res = await fetch(`https://snagged.onrender.com/api/messages/${to}`, {
+      const res = await fetch(`${API_BASE}/messages/${to}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -27,7 +28,7 @@ const MessagesPage = () => {
   const handleSend = async (e) => {
     e.preventDefault();
     try {
-      await fetch('https://snagged.onrender.com/api/messages', {
+      await fetch(`${API_BASE}/messages`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/pages/PostTaskPage.jsx
+++ b/client/src/pages/PostTaskPage.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const PostTaskPage = () => {
   const [formData, setFormData] = useState({
@@ -31,7 +32,7 @@ const PostTaskPage = () => {
     e.preventDefault();
     const token = localStorage.getItem('token');
     try {
-      const res = await fetch('https://snagged.onrender.com/api/tasks', {
+      const res = await fetch(`${API_BASE}/tasks`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/pages/ResetPasswordPage.jsx
+++ b/client/src/pages/ResetPasswordPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import { API_BASE } from '../utils/api';
 
 const ResetPasswordPage = () => {
   const { token } = useParams();
@@ -18,7 +19,7 @@ const ResetPasswordPage = () => {
     }
 
     try {
-      const res = await axios.post(`${import.meta.env.VITE_API_URL}/auth/reset-password/${token}`, {
+      const res = await axios.post(`${API_BASE}/auth/reset-password/${token}`, {
         password,
       });
 

--- a/client/src/pages/SignupPage.jsx
+++ b/client/src/pages/SignupPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const SignupPage = () => {
   const [formData, setFormData] = useState({
@@ -17,10 +18,9 @@ const SignupPage = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log('form submitted');
 
     try {
-      const res = await fetch('https://snagged.onrender.com/api/auth/signup', {
+      const res = await fetch(`${API_BASE}/auth/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData),
@@ -84,7 +84,7 @@ const SignupPage = () => {
       <button
         type="button"
         className="google-login-button"
-        onClick={() => window.location.href = 'https://snagged.onrender.com/api/auth/google'}
+        onClick={() => window.location.href = `${API_BASE}/auth/google`}
       >
         <img
           src="https://developers.google.com/identity/images/g-logo.png"

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -1,0 +1,1 @@
+export const API_BASE = import.meta.env.VITE_API_URL || 'https://snagged.onrender.com/api';


### PR DESCRIPTION
## Summary
- switch to a dark palette in App.css
- centralize API base URL in a helper
- use helper across pages and remove a console log
- update inputs for dark mode
- set site title to `Snagged`

## Testing
- `npm run lint` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68790ebca5dc83339983938a2363c158