### PR TITLE
Improve styling and API config

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Snagged</title>
 
     <!-- Global font -->
     <link

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,10 +23,13 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "autoprefixer": "^10.4.21",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.11",
         "vite": "^6.3.5"
       }
     },
@@ -1493,6 +1496,44 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
@@ -2237,6 +2278,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2675,6 +2730,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/oauth": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
@@ -2893,6 +2958,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -3148,6 +3220,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
+      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/client/package.json
+++ b/client/package.json
@@ -25,10 +25,13 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "autoprefixer": "^10.4.21",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.11",
     "vite": "^6.3.5"
   }
 }

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,12 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
-  --primary-color: #6366f1;
-  --primary-hover: #4f46e5;
-  --bg-color: #f9fafb;
-  --card-bg: #ffffff;
-  --text-color: #1f2937;
-  --border-color: #e5e7eb;
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.1);
-  --shadow-md: 0 2px 6px rgba(0,0,0,0.15);
+  /* Dark mode palette */
+  --primary-color: #4b5563;
+  --primary-hover: #6b7280;
+  --bg-color: #111827;
+  --card-bg: #1f2937;
+  --text-color: #f3f4f6;
+  --border-color: #374151;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.4);
+  --shadow-md: 0 2px 6px rgba(0,0,0,0.5);
 }
 
 html {
@@ -116,7 +121,7 @@ a {
 .hero-text p {
   font-size: 1.125rem;
   margin-bottom: 2rem;
-  color: #4b5563;
+  color: #d1d5db;
 }
 
 .hero-image img {
@@ -181,7 +186,8 @@ a {
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
   font-size: 1rem;
-  background-color: #fff;
+  background-color: var(--bg-color);
+  color: var(--text-color);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -190,13 +196,13 @@ a {
 .signup-form textarea:focus,
 .text-input:focus {
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+  box-shadow: 0 0 0 3px rgba(107, 114, 128, 0.2);
   outline: none;
 }
 
 .google-login-button {
   margin-top: 0.5rem;
-  background-color: #fff;
+  background-color: var(--bg-color);
   color: var(--primary-color);
   border: 1px solid var(--primary-color);
   display: flex;
@@ -205,7 +211,7 @@ a {
 }
 
 .google-login-button:hover {
-  background-color: rgba(99, 102, 241, 0.1);
+  background-color: var(--primary-hover);
 }
 
 .google-logo {

--- a/client/src/pages/ForgotPasswordPage.jsx
+++ b/client/src/pages/ForgotPasswordPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const ForgotPasswordPage = () => {
   const [email, setEmail] = useState('');
@@ -10,7 +11,7 @@ const ForgotPasswordPage = () => {
     e.preventDefault();
 
     try {
-      const res = await axios.post('https://snagged.onrender.com/api/auth/forgot-password', {
+      const res = await axios.post(`${API_BASE}/auth/forgot-password`, {
         email,
       });
       setMessage(res.data.message || 'Reset email sent if user exists.');

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -4,45 +4,43 @@ import heroImg from '../assets/hero-application.png';
 
 const LandingPage = () => {
   return (
-    <div className="landing">
-      <nav className="top-nav">
-        <div className="logo">Snagged</div>
-        <div className="nav-buttons">
-          <a href="/login" className="nav-btn">Login</a>
-          <a href="/signup" className="nav-btn">Sign Up</a>
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-black via-gray-900 to-gray-800 text-gray-200 font-sans">
+      <nav className="flex items-center justify-between px-6 py-4">
+        <div className="text-2xl font-bold tracking-wide">Snagged</div>
+        <div className="space-x-4">
+          <a href="/login" className="px-4 py-2 rounded-md bg-gray-700 hover:bg-gray-600 transition">Login</a>
+          <a href="/signup" className="px-4 py-2 rounded-md bg-gray-100 text-gray-900 hover:bg-gray-300 transition">Sign Up</a>
         </div>
       </nav>
 
-      <header className="hero">
-        <div className="hero-text">
-          <h1>Snagged</h1>
-          <p>
-            Apply like a boss without lifting a finger. Snagged pairs you with fellow students ready to grind through applications so you can vibe and study.
-          </p>
-          <a href="/signup" className="cta-button">Get Started</a>
-        </div>
-        <div className="hero-image">
-          <img src={heroImg} alt="Job Application" />
-        </div>
+      <header className="flex flex-col items-center text-center flex-grow px-6 mt-12">
+        <h1 className="text-5xl md:text-6xl font-extrabold mb-4 opacity-0 animate-fade-up" style={{ animationDelay: '0.1s' }}>Snagged</h1>
+        <p className="max-w-xl mb-6 text-gray-300 text-lg opacity-0 animate-fade-up" style={{ animationDelay: '0.2s' }}>
+          Apply like a boss without lifting a finger. Snagged pairs you with fellow students ready to grind through applications so you can vibe and study.
+        </p>
+        <a href="/signup" className="px-6 py-3 rounded-lg bg-gray-700 hover:bg-gray-600 shadow-lg transition opacity-0 animate-fade-up" style={{ animationDelay: '0.3s' }}>
+          Get Started
+        </a>
+        <img src={heroImg} alt="Job Application" className="w-full max-w-md mt-10 opacity-0 animate-fade-up" style={{ animationDelay: '0.4s' }} />
       </header>
 
-      <section className="features">
-        <div className="feature-box">
-          <h3>🌍 <strong>Global Snaggers</strong></h3>
+      <section className="grid gap-6 md:grid-cols-3 px-6 py-12 opacity-0 animate-fade-up" style={{ animationDelay: '0.5s' }}>
+        <div className="bg-gray-900/50 rounded-xl p-6 shadow">
+          <h3 className="text-lg font-semibold mb-2">🌍 Global Snaggers</h3>
           <p>Find trusted Snaggers worldwide to knock out your internship apps — way faster and cheaper than doing it solo.</p>
         </div>
-        <div className="feature-box">
-          <h3>💸 <strong>Price Flexibility</strong></h3>
+        <div className="bg-gray-900/50 rounded-xl p-6 shadow">
+          <h3 className="text-lg font-semibold mb-2">💸 Price Flexibility</h3>
           <p>Every budget, every preference — you decide how much you're willing to pay. If one helper's rate is too high, browse others.</p>
         </div>
-        <div className="feature-box">
-          <h3>🤝 <strong>Like a Social Network</strong></h3>
+        <div className="bg-gray-900/50 rounded-xl p-6 shadow">
+          <h3 className="text-lg font-semibold mb-2">🤝 Like a Social Network</h3>
           <p>Think Fiverr meets LinkedIn — but built for job applications. Scope profiles, chat with Snaggers, and get your apps sent stress-free.</p>
         </div>
       </section>
 
-      <footer className="footer">
-        <p>© 2025 Snagged • <a href="/about">About</a> • <a href="/contact">Contact</a></p>
+      <footer className="text-center py-6 text-sm text-gray-500">
+        © 2025 Snagged • <a href="/about" className="hover:underline">About</a> • <a href="/contact" className="hover:underline">Contact</a>
       </footer>
     </div>
   );

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import { useNavigate, Link } from 'react-router-dom';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const LoginPage = () => {
   const [email, setEmail] = useState('');
@@ -18,7 +19,7 @@ const LoginPage = () => {
     setErrorMsg('');
 
     try {
-      const res = await axios.post('https://snagged.onrender.com/api/auth/login', {
+      const res = await axios.post(`${API_BASE}/auth/login`, {
         email,
         password,
       });
@@ -73,7 +74,7 @@ const LoginPage = () => {
           type="button"
           className="google-login-button"
           onClick={() =>
-            (window.location.href = 'https://snagged.onrender.com/api/auth/google')
+            (window.location.href = `${API_BASE}/auth/google`)
           }
         >
           <img

--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const MainPage = () => {
   const [role, setRole] = useState(null);
@@ -70,7 +71,7 @@ const SnaggerDashboard = () => {
     if (filters.campus) params.append('campus', filters.campus);
 
     try {
-      const res = await fetch(`https://snagged.onrender.com/api/tasks?${params.toString()}`, {
+      const res = await fetch(`${API_BASE}/tasks?${params.toString()}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -86,7 +87,7 @@ const SnaggerDashboard = () => {
   const handleFilter = (e) => { e.preventDefault(); fetchTasks(); };
 
   const claimTask = async (id) => {
-    await fetch(`https://snagged.onrender.com/api/tasks/${id}/claim`, {
+    await fetch(`${API_BASE}/tasks/${id}/claim`, {
       method: 'PUT',
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/client/src/pages/MessagesPage.jsx
+++ b/client/src/pages/MessagesPage.jsx
@@ -1,5 +1,6 @@
 // Basic messaging UI - merge conflicts resolved
 import React, { useState, useEffect, useCallback } from 'react';
+import { API_BASE } from '../utils/api';
 
 const MessagesPage = () => {
   const [messages, setMessages] = useState([]);
@@ -10,7 +11,7 @@ const MessagesPage = () => {
   const fetchMessages = useCallback(async () => {
     if (!to) return;
     try {
-      const res = await fetch(`https://snagged.onrender.com/api/messages/${to}`, {
+      const res = await fetch(`${API_BASE}/messages/${to}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -27,7 +28,7 @@ const MessagesPage = () => {
   const handleSend = async (e) => {
     e.preventDefault();
     try {
-      await fetch('https://snagged.onrender.com/api/messages', {
+      await fetch(`${API_BASE}/messages`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/pages/PostTaskPage.jsx
+++ b/client/src/pages/PostTaskPage.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const PostTaskPage = () => {
   const [formData, setFormData] = useState({
@@ -31,7 +32,7 @@ const PostTaskPage = () => {
     e.preventDefault();
     const token = localStorage.getItem('token');
     try {
-      const res = await fetch('https://snagged.onrender.com/api/tasks', {
+      const res = await fetch(`${API_BASE}/tasks`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/pages/ResetPasswordPage.jsx
+++ b/client/src/pages/ResetPasswordPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import { API_BASE } from '../utils/api';
 
 const ResetPasswordPage = () => {
   const { token } = useParams();
@@ -18,7 +19,7 @@ const ResetPasswordPage = () => {
     }
 
     try {
-      const res = await axios.post(`${import.meta.env.VITE_API_URL}/auth/reset-password/${token}`, {
+      const res = await axios.post(`${API_BASE}/auth/reset-password/${token}`, {
         password,
       });
 

--- a/client/src/pages/SignupPage.jsx
+++ b/client/src/pages/SignupPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import '../App.css';
+import { API_BASE } from '../utils/api';
 
 const SignupPage = () => {
   const [formData, setFormData] = useState({
@@ -17,10 +18,9 @@ const SignupPage = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log('form submitted');
 
     try {
-      const res = await fetch('https://snagged.onrender.com/api/auth/signup', {
+      const res = await fetch(`${API_BASE}/auth/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData),
@@ -84,7 +84,7 @@ const SignupPage = () => {
       <button
         type="button"
         className="google-login-button"
-        onClick={() => window.location.href = 'https://snagged.onrender.com/api/auth/google'}
+        onClick={() => window.location.href = `${API_BASE}/auth/google`}
       >
         <img
           src="https://developers.google.com/identity/images/g-logo.png"

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -1,0 +1,1 @@
+export const API_BASE = import.meta.env.VITE_API_URL || 'https://snagged.onrender.com/api';

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,17 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      keyframes: {
+        'fade-up': {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        'fade-up': 'fade-up 0.6s ease-out forwards',
+      },
+    },
+  },
+  plugins: [],
+}

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,8 @@ const PORT = process.env.PORT || 5000;
 
 // CORS Configuration
 app.use(cors({
-  origin: 'https://snagged.dev', // ✅ No trailing slash
+  // Allow requests from the configured frontend URL
+  origin: process.env.CLIENT_URL || 'http://localhost:5173',
   credentials: true,
 }));
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -76,7 +76,8 @@ router.get('/google/callback', passport.authenticate('google', {
     expiresIn: '7d',
   });
 
-  res.redirect(`https://snagged.dev/main?token=${token}&role=${req.user.role}`);
+  // Redirect back to the client with token in query string
+  res.redirect(`${CLIENT_URL}/main?token=${token}&role=${req.user.role}`);
 });
 
 // Forgot Password Route


### PR DESCRIPTION
## Summary
- switch to a dark palette in App.css
- centralize API base URL in a helper
- use helper across pages and remove a console log
- update inputs for dark mode
- set site title to `Snagged`
- use `CLIENT_URL` env for CORS and OAuth redirects
- add Tailwind CSS and redesign landing page

## Testing
- `npm install && npm run lint` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68790ebca5dc83339983938a2363c158